### PR TITLE
Adding extention to body message

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -233,7 +233,7 @@ class TrumpTweetPlugin(Plugin):
         info.width, info.height = img.size
         info.mimetype = "image/png"
         content.info = info
-        content.body = "tweet"
+        content.body = "tweet.png"
         content.msgtype = "m.image"
         content.url = mxc_uri
 


### PR DESCRIPTION
Some bots/external services (e.g. [maubot-telegram](https://github.com/mautrix/telegram)) embedded the image only when the message body has an image extension, i.e. `.png`.